### PR TITLE
Fix region ordering and coordinate scaling in OCR crop

### DIFF
--- a/src/PhotoOCR.tsx
+++ b/src/PhotoOCR.tsx
@@ -84,9 +84,15 @@ function PhotoOCR({ translationLanguage, onCardAdded }: PhotoOCRProps) {
 
   const getCoords = (e: React.MouseEvent | React.TouchEvent): { x: number; y: number } => {
     const canvas = canvasRef.current!;
-    const rect = canvas.getBoundingClientRect();
+    const displayRect = canvas.getBoundingClientRect();
     const src = "touches" in e ? e.touches[0] : (e as React.MouseEvent);
-    return { x: src.clientX - rect.left, y: src.clientY - rect.top };
+    const cssX = src.clientX - displayRect.left;
+    const cssY = src.clientY - displayRect.top;
+    // Convert from CSS display pixels to canvas pixel space (differs when max-width scales canvas down)
+    return {
+      x: cssX * (canvas.width / displayRect.width),
+      y: cssY * (canvas.height / displayRect.height),
+    };
   };
 
   const onPointerDown = (e: React.MouseEvent | React.TouchEvent) => {
@@ -126,12 +132,16 @@ function PhotoOCR({ translationLanguage, onCardAdded }: PhotoOCRProps) {
     const scaleX = img.naturalWidth / canvas.width;
     const scaleY = img.naturalHeight / canvas.height;
 
-    const sorted = [...rects]
-      .map((r) => ({ x: r.x * scaleX, y: r.y * scaleY, w: r.w * scaleX, h: r.h * scaleY }))
-      .sort((a, b) => a.y - b.y);
+    // Use draw order (the numbered labels), not Y position — users draw in reading order
+    const scaled = rects.map((r) => ({
+      x: r.x * scaleX,
+      y: r.y * scaleY,
+      w: r.w * scaleX,
+      h: r.h * scaleY,
+    }));
 
-    const totalWidth = Math.max(...sorted.map((r) => r.w));
-    const totalHeight = sorted.reduce((sum, r) => sum + r.h, 0);
+    const totalWidth = Math.max(...scaled.map((r) => r.w));
+    const totalHeight = scaled.reduce((sum, r) => sum + r.h, 0);
 
     const out = document.createElement("canvas");
     out.width = totalWidth;
@@ -141,7 +151,7 @@ function PhotoOCR({ translationLanguage, onCardAdded }: PhotoOCRProps) {
     ctx.fillRect(0, 0, totalWidth, totalHeight);
 
     let offsetY = 0;
-    for (const r of sorted) {
+    for (const r of scaled) {
       ctx.drawImage(img, r.x, r.y, r.w, r.h, 0, offsetY, r.w, r.h);
       offsetY += r.h;
     }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -23,7 +23,7 @@
   "chinese": "Chinese",
   "tab_text": "Text",
   "tab_photo": "OCR Photo",
-  "drag_to_select": "Drag to select regions. Draw multiple regions to capture text across lines.",
+  "drag_to_select": "Drag to select regions in reading order. They will be stacked in the order drawn.",
   "remove_last": "Remove last region",
   "clear_regions": "Clear all regions",
   "crop_and_submit": "Get Meaning",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -23,7 +23,7 @@
   "chinese": "中国語",
   "tab_text": "テキスト",
   "tab_photo": "OCR写真",
-  "drag_to_select": "ドラッグして範囲を選択。複数の範囲を選択して行をまたいだテキストを取得できます。",
+  "drag_to_select": "読む順番にドラッグして範囲を選択。描いた順番に積み重ねて送信されます。",
   "remove_last": "最後の範囲を削除",
   "clear_regions": "全範囲を削除",
   "crop_and_submit": "意味を取得",


### PR DESCRIPTION
- Remove Y-sort in favour of draw order: regions are stacked in the order the user drew them (matching the numbered labels), not by Y position. This is correct for both vertical (right-to-left) and horizontal text where the user knows the reading order.
- Fix coordinate scaling: getCoords now converts CSS display pixels to canvas pixel space before storing, so crops are accurate when max-width CSS scales the canvas smaller than its pixel dimensions.
- Update instruction text to tell users to draw in reading order.

https://claude.ai/code/session_01PDvScyVeq9Sxm17G5AKHsf