### PR TITLE
Add stroke-order numbers to JP diagrams

### DIFF
--- a/scripts/bundle-data.js
+++ b/scripts/bundle-data.js
@@ -10,8 +10,9 @@ const outDir = path.join(root, "public", "data");
 fs.mkdirSync(outDir, { recursive: true });
 
 // ── KanjiVG ──────────────────────────────────────────────────────────────────
-// Extracts path `d` attributes from each minified SVG.
-// Output: { "05c71": ["M52.49,15.5...", ...], ... }
+// Extracts path `d` attributes from each minified SVG, and stroke start
+// positions from the paired JSON (used to render stroke-order numbers).
+// Output: { "05c71": { paths: ["M52.49,..."], starts: [{x,y},...] }, ... }
 const kanjivgDir = path.join(root, "node_modules", "@madcat", "kanjivg", "dist", "main");
 const kanjivgOut = {};
 const svgFiles = fs.readdirSync(kanjivgDir).filter((f) => f.endsWith(".svg"));
@@ -22,7 +23,10 @@ for (const file of svgFiles) {
   const re = / d="([^"]+)"/g;
   let m;
   while ((m = re.exec(svg)) !== null) paths.push(m[1]);
-  if (paths.length > 0) kanjivgOut[cp] = paths;
+  if (paths.length === 0) continue;
+  const strokeMeta = JSON.parse(fs.readFileSync(path.join(kanjivgDir, `${cp}.json`), "utf-8"));
+  const starts = strokeMeta.map((s) => s.start);
+  kanjivgOut[cp] = { paths, starts };
 }
 fs.writeFileSync(path.join(outDir, "kanjivg.json"), JSON.stringify(kanjivgOut));
 console.log(`kanjivg.json: ${svgFiles.length} kanji`);

--- a/src/diagrams.ts
+++ b/src/diagrams.ts
@@ -42,9 +42,13 @@ function renderSvgBlob(
   });
 }
 
-// Keyed by 5-digit hex codepoint; value is an array of SVG path `d` strings.
+// Keyed by 5-digit hex codepoint.
 // Bundled from @madcat/kanjivg by scripts/bundle-data.js.
-type KanjivgData = Record<string, string[]>;
+interface KanjivgEntry {
+  paths: string[];
+  starts: Array<{ x: number; y: number }>;
+}
+type KanjivgData = Record<string, KanjivgEntry>;
 
 // Lazy singleton — fetched once per session, then served offline by the SW.
 let kanjivgLoad: Promise<KanjivgData> | null = null;
@@ -74,17 +78,25 @@ export async function generateJPDiagram(word: string): Promise<string | null> {
 
   for (let i = 0; i < chars.length; i++) {
     const cp = chars[i].codePointAt(0)!.toString(16).padStart(5, "0");
-    const paths = kanjivg[cp];
-    if (!paths) continue;
+    const entry = kanjivg[cp];
+    if (!entry) continue;
 
-    const pathElems = paths
+    const pathElems = entry.paths
       .map(
         (d, pi) =>
           `<path d="${d}" style="stroke:${STROKE_COLORS[pi % STROKE_COLORS.length]};stroke-width:3;fill:none;stroke-linecap:round;stroke-linejoin:round;"/>`
       )
       .join("");
-    const svgStr = `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 109 109">${pathElems}</svg>`;
 
+    // viewBox is 109x109; font-size ~9 keeps numbers legible at that scale
+    const numberElems = entry.starts
+      .map(
+        ({ x, y }, si) =>
+          `<text x="${x}" y="${y}" font-size="9" fill="white" stroke="#333" stroke-width="2.2" paint-order="stroke" text-anchor="middle" dominant-baseline="middle" font-family="sans-serif" font-weight="bold">${si + 1}</text>`
+      )
+      .join("");
+
+    const svgStr = `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 109 109">${pathElems}${numberElems}</svg>`;
     await renderSvgBlob(svgStr, ctx, i * size, 0, size);
   }
 


### PR DESCRIPTION
@madcat/kanjivg ships paired .json files alongside each SVG containing the start {x,y} of every stroke in the 109x109 coordinate space. Include those in the kanjivg.json bundle and render numbered labels at the stroke start points, matching the CN diagram behaviour.

- bundle-data.js: read <cp>.json alongside each SVG; store { paths, starts }
- diagrams.ts: KanjivgEntry type now holds starts[]; overlay <text> elements at each start position (font-size 9 for the 109×109 viewBox)

kanjivg.json grows from 6.3 → 8.1 MB (2.4 → 2.9 MB gzipped).

https://claude.ai/code/session_012A6Ht1UJ87ULGBFUfoPUqs