### PR TITLE
Add test suite (58 tests) and add test + type-check to CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,4 +28,5 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npx tsc --noEmit
+    - run: npm test -- --watchAll=false
     - run: npm run build --if-present

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@auth0/auth0-react": "^2.18.0",
         "@madcat/kanjivg": "^5.0.0",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -3765,6 +3766,40 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "license": "MIT"
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -3839,6 +3874,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6631,6 +6672,15 @@
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -12568,6 +12618,15 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -20938,6 +20997,36 @@
         "loader-utils": "^2.0.0"
       }
     },
+    "@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "dependencies": {
+        "aria-query": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+          "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+          "requires": {
+            "dequal": "^2.0.3"
+          }
+        },
+        "dom-accessibility-api": {
+          "version": "0.5.16",
+          "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+          "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="
+        }
+      }
+    },
     "@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -20973,6 +21062,11 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA=="
+    },
+    "@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="
     },
     "@types/babel__core": {
       "version": "7.20.5",
@@ -23033,6 +23127,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+    },
+    "dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
     "destroy": {
       "version": "1.2.0",
@@ -27295,6 +27394,11 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="
     },
     "magic-string": {
       "version": "0.25.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+        "@types/jest": "^30.0.0",
         "@types/papaparse": "^5.5.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -2873,6 +2874,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.5.1.tgz",
@@ -2885,6 +2896,19 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
@@ -2903,6 +2927,16 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/globals": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.5.1.tgz",
@@ -2914,6 +2948,30 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
@@ -4044,6 +4102,305 @@
       "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-message-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-mock": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@types/json-schema": {
@@ -15308,6 +15665,22 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -20386,6 +20759,12 @@
         }
       }
     },
+    "@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "dev": true
+    },
     "@jest/environment": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.5.1.tgz",
@@ -20395,6 +20774,15 @@
         "@jest/types": "^27.5.1",
         "@types/node": "*",
         "jest-mock": "^27.5.1"
+      }
+    },
+    "@jest/expect-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+      "dev": true,
+      "requires": {
+        "@jest/get-type": "30.1.0"
       }
     },
     "@jest/fake-timers": {
@@ -20410,6 +20798,12 @@
         "jest-util": "^27.5.1"
       }
     },
+    "@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true
+    },
     "@jest/globals": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.5.1.tgz",
@@ -20418,6 +20812,24 @@
         "@jest/environment": "^27.5.1",
         "@jest/types": "^27.5.1",
         "expect": "^27.5.1"
+      }
+    },
+    "@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "dependencies": {
+        "jest-regex-util": {
+          "version": "30.4.0",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+          "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+          "dev": true
+        }
       }
     },
     "@jest/reporters": {
@@ -21233,6 +21645,219 @@
       "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
       "requires": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "requires": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      },
+      "dependencies": {
+        "@jest/schemas": {
+          "version": "30.4.1",
+          "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+          "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+          "dev": true,
+          "requires": {
+            "@sinclair/typebox": "^0.34.0"
+          }
+        },
+        "@jest/types": {
+          "version": "30.4.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+          "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+          "dev": true,
+          "requires": {
+            "@jest/pattern": "30.4.0",
+            "@jest/schemas": "30.4.1",
+            "@types/istanbul-lib-coverage": "^2.0.6",
+            "@types/istanbul-reports": "^3.0.4",
+            "@types/node": "*",
+            "@types/yargs": "^17.0.33",
+            "chalk": "^4.1.2"
+          }
+        },
+        "@sinclair/typebox": {
+          "version": "0.34.49",
+          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+          "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+          "dev": true
+        },
+        "@types/yargs": {
+          "version": "17.0.35",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+          "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "ci-info": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+          "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "expect": {
+          "version": "30.4.1",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+          "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+          "dev": true,
+          "requires": {
+            "@jest/expect-utils": "30.4.1",
+            "@jest/get-type": "30.1.0",
+            "jest-matcher-utils": "30.4.1",
+            "jest-message-util": "30.4.1",
+            "jest-mock": "30.4.1",
+            "jest-util": "30.4.1"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "30.4.1",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+          "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+          "dev": true,
+          "requires": {
+            "@jest/diff-sequences": "30.4.0",
+            "@jest/get-type": "30.1.0",
+            "chalk": "^4.1.2",
+            "pretty-format": "30.4.1"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "30.4.1",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+          "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+          "dev": true,
+          "requires": {
+            "@jest/get-type": "30.1.0",
+            "chalk": "^4.1.2",
+            "jest-diff": "30.4.1",
+            "pretty-format": "30.4.1"
+          }
+        },
+        "jest-message-util": {
+          "version": "30.4.1",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+          "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.27.1",
+            "@jest/types": "30.4.1",
+            "@types/stack-utils": "^2.0.3",
+            "chalk": "^4.1.2",
+            "graceful-fs": "^4.2.11",
+            "jest-util": "30.4.1",
+            "picomatch": "^4.0.3",
+            "pretty-format": "30.4.1",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.6"
+          }
+        },
+        "jest-mock": {
+          "version": "30.4.1",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+          "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "30.4.1",
+            "@types/node": "*",
+            "jest-util": "30.4.1"
+          }
+        },
+        "jest-util": {
+          "version": "30.4.1",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+          "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "30.4.1",
+            "@types/node": "*",
+            "chalk": "^4.1.2",
+            "ci-info": "^4.2.0",
+            "graceful-fs": "^4.2.11",
+            "picomatch": "^4.0.3"
+          }
+        },
+        "picomatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "30.4.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+          "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "30.4.1",
+            "ansi-styles": "^5.2.0",
+            "react-is-18": "npm:react-is@^18.3.1",
+            "react-is-19": "npm:react-is@^19.2.5"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true
+            }
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@types/json-schema": {
@@ -29097,6 +29722,18 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-is-18": {
+      "version": "npm:react-is@18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true
+    },
+    "react-is-19": {
+      "version": "npm:react-is@19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "dev": true
     },
     "react-refresh": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "@types/jest": "^30.0.0",
     "@types/papaparse": "^5.5.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@auth0/auth0-react": "^2.18.0",
     "@madcat/kanjivg": "^5.0.0",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/src/__tests__/Cards.test.tsx
+++ b/src/__tests__/Cards.test.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Cards from '../Cards';
+
+// Build a mock JWT whose payload decodes to the given permissions
+function makeToken(permissions: string[] = []) {
+  const payload = btoa(JSON.stringify({ permissions }));
+  return `header.${payload}.sig`;
+}
+
+const mockGetToken = jest.fn().mockResolvedValue(makeToken());
+
+jest.mock('@auth0/auth0-react', () => ({
+  useAuth0: () => ({ getAccessTokenSilently: mockGetToken }),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// Stub heavy child components
+jest.mock('../LogoutButton', () => () => <button>Logout</button>);
+jest.mock('../WritingCard', () => () => <div data-testid="writing-card" />);
+jest.mock('../PhotoOCR', () => () => <div data-testid="photo-ocr" />);
+jest.mock('../Settings', () => ({ settingsUpdated }: { settingsUpdated: (s: unknown) => void }) => (
+  <div data-testid="settings" />
+));
+
+beforeEach(() => {
+  localStorage.clear();
+  mockGetToken.mockResolvedValue(makeToken());
+});
+
+describe('Cards – initial render', () => {
+  it('renders the app title', async () => {
+    render(<Cards />);
+    await waitFor(() => expect(screen.getByText('welcome')).toBeInTheDocument());
+  });
+
+  it('shows an empty sentence textarea by default', async () => {
+    render(<Cards />);
+    await waitFor(() => {
+      const textareas = screen.getAllByRole('textbox');
+      expect(textareas.length).toBeGreaterThanOrEqual(1);
+      expect(textareas[0]).toHaveValue('');
+    });
+  });
+
+  it('loads saved sentences from localStorage', async () => {
+    localStorage.setItem('sentences', JSON.stringify([{ text: 'こんにちは', meaning: 'Hello', reading: 'こんにちは' }]));
+    render(<Cards />);
+    await waitFor(() => expect(screen.getByDisplayValue('こんにちは')).toBeInTheDocument());
+  });
+});
+
+describe('Cards – sentence management', () => {
+  it('adds a new sentence field when the add button is clicked', async () => {
+    render(<Cards />);
+    await waitFor(() => screen.getByText('add_sentence'));
+    const before = screen.getAllByRole('textbox').length;
+    await userEvent.click(screen.getByText('add_sentence'));
+    expect(screen.getAllByRole('textbox').length).toBe(before + 1);
+  });
+
+  it('updates a sentence textarea when typed into', async () => {
+    render(<Cards />);
+    await waitFor(() => screen.getAllByRole('textbox'));
+    const textarea = screen.getAllByRole('textbox')[0];
+    await userEvent.type(textarea, '猫');
+    expect(textarea).toHaveValue('猫');
+  });
+
+  it('persists sentences to localStorage on change', async () => {
+    render(<Cards />);
+    await waitFor(() => screen.getAllByRole('textbox'));
+    await userEvent.type(screen.getAllByRole('textbox')[0], 'テスト');
+    await waitFor(() => {
+      const saved = JSON.parse(localStorage.getItem('sentences') || '[]');
+      expect(saved[0].text).toContain('テスト');
+    });
+  });
+
+  it('clears all sentences when confirmed', async () => {
+    localStorage.setItem('sentences', JSON.stringify([
+      { text: '猫', meaning: 'cat', reading: 'ねこ' },
+      { text: '犬', meaning: 'dog', reading: 'いぬ' },
+    ]));
+    jest.spyOn(window, 'confirm').mockReturnValueOnce(true);
+    render(<Cards />);
+    await waitFor(() => screen.getByDisplayValue('猫'));
+    await userEvent.click(screen.getByText('clear_all'));
+    await waitFor(() => {
+      const textareas = screen.getAllByRole('textbox');
+      expect(textareas.length).toBe(1);
+      expect(textareas[0]).toHaveValue('');
+    });
+  });
+
+  it('does not clear sentences when the confirmation is cancelled', async () => {
+    localStorage.setItem('sentences', JSON.stringify([{ text: '猫', meaning: 'cat', reading: 'ねこ' }]));
+    jest.spyOn(window, 'confirm').mockReturnValueOnce(false);
+    render(<Cards />);
+    await waitFor(() => screen.getByDisplayValue('猫'));
+    await userEvent.click(screen.getByText('clear_all'));
+    expect(screen.getByDisplayValue('猫')).toBeInTheDocument();
+  });
+});
+
+describe('Cards – tab navigation', () => {
+  it('shows the Text tab content by default', async () => {
+    render(<Cards />);
+    await waitFor(() => {
+      expect(screen.getAllByRole('textbox').length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('switches to kanji writing tab', async () => {
+    render(<Cards />);
+    await waitFor(() => screen.getByText('tab_kanji_writing'));
+    await userEvent.click(screen.getByText('tab_kanji_writing'));
+    expect(screen.getByTestId('writing-card')).toBeInTheDocument();
+  });
+
+  it('switches to hanzi writing tab', async () => {
+    render(<Cards />);
+    await waitFor(() => screen.getByText('tab_hanzi_writing'));
+    await userEvent.click(screen.getByText('tab_hanzi_writing'));
+    expect(screen.getByTestId('writing-card')).toBeInTheDocument();
+  });
+
+  it('shows the OCR photo tab when the token grants use:photo-ocr', async () => {
+    mockGetToken.mockResolvedValue(makeToken(['use:photo-ocr']));
+    render(<Cards />);
+    await waitFor(() => expect(screen.getByText('tab_photo')).toBeInTheDocument());
+    await userEvent.click(screen.getByText('tab_photo'));
+    expect(screen.getByTestId('photo-ocr')).toBeInTheDocument();
+  });
+
+  it('hides the OCR photo tab when the token lacks the permission', async () => {
+    render(<Cards />);
+    await waitFor(() => screen.getByText('tab_text'));
+    expect(screen.queryByText('tab_photo')).not.toBeInTheDocument();
+  });
+});
+
+describe('Cards – language selection', () => {
+  it('defaults to Japanese (jp-JP)', async () => {
+    render(<Cards />);
+    await waitFor(() => {
+      const select = screen.getByRole('combobox');
+      expect(select).toHaveValue('jp-JP');
+    });
+  });
+
+  it('loads saved language from localStorage', async () => {
+    localStorage.setItem('translationLanguage', 'zh-CN');
+    render(<Cards />);
+    await waitFor(() => expect(screen.getByRole('combobox')).toHaveValue('zh-CN'));
+  });
+
+  it('persists language selection to localStorage when changed', async () => {
+    render(<Cards />);
+    await waitFor(() => screen.getByRole('combobox'));
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'zh-CN');
+    expect(localStorage.getItem('translationLanguage')).toBe('zh-CN');
+  });
+});

--- a/src/__tests__/Settings.test.tsx
+++ b/src/__tests__/Settings.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SettingsComponent from '../Settings';
+import { AppSettings } from '../types/AppSettings';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const defaults: AppSettings = {
+  ankConnect: true,
+  ankiConnectUrl: 'http://localhost:8765',
+  ankiDeck: 'Default',
+  ankiModel: 'Basic',
+};
+
+describe('SettingsComponent', () => {
+  it('renders the Settings button', () => {
+    render(<SettingsComponent settingsUpdated={jest.fn()} defaultSettings={defaults} />);
+    expect(screen.getByRole('button', { name: 'Settings' })).toBeInTheDocument();
+  });
+
+  it('modal is hidden by default', () => {
+    render(<SettingsComponent settingsUpdated={jest.fn()} defaultSettings={defaults} />);
+    expect(document.querySelector('.modal')).toHaveStyle({ display: 'none' });
+  });
+
+  it('opens modal when Settings button is clicked', async () => {
+    render(<SettingsComponent settingsUpdated={jest.fn()} defaultSettings={defaults} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Settings' }));
+    expect(document.querySelector('.modal')).toHaveStyle({ display: 'block' });
+  });
+
+  it('closes modal when the × button is clicked', async () => {
+    render(<SettingsComponent settingsUpdated={jest.fn()} defaultSettings={defaults} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Settings' }));
+    await userEvent.click(screen.getByText('×'));
+    expect(document.querySelector('.modal')).toHaveStyle({ display: 'none' });
+  });
+
+  it('calls settingsUpdated with the new value when the checkbox changes', async () => {
+    const onUpdate = jest.fn();
+    render(<SettingsComponent settingsUpdated={onUpdate} defaultSettings={defaults} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Settings' }));
+    await userEvent.click(screen.getByRole('checkbox'));
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ ankConnect: false }));
+  });
+
+  it('calls settingsUpdated when the URL input is changed', async () => {
+    const onUpdate = jest.fn();
+    render(<SettingsComponent settingsUpdated={onUpdate} defaultSettings={defaults} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Settings' }));
+    const urlInput = screen.getByDisplayValue('http://localhost:8765');
+    await userEvent.clear(urlInput);
+    await userEvent.type(urlInput, 'http://localhost:9000');
+    expect(onUpdate).toHaveBeenLastCalledWith(expect.objectContaining({ ankiConnectUrl: 'http://localhost:9000' }));
+  });
+
+  it('calls settingsUpdated when the deck name is changed', async () => {
+    const onUpdate = jest.fn();
+    render(<SettingsComponent settingsUpdated={onUpdate} defaultSettings={defaults} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Settings' }));
+    const deckInput = screen.getByDisplayValue('Default');
+    await userEvent.clear(deckInput);
+    await userEvent.type(deckInput, 'MyDeck');
+    expect(onUpdate).toHaveBeenLastCalledWith(expect.objectContaining({ ankiDeck: 'MyDeck' }));
+  });
+
+  it('closes modal after clicking Save Settings', async () => {
+    render(<SettingsComponent settingsUpdated={jest.fn()} defaultSettings={defaults} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Settings' }));
+    await userEvent.click(screen.getByDisplayValue('Save Settings'));
+    expect(document.querySelector('.modal')).toHaveStyle({ display: 'none' });
+  });
+});

--- a/src/__tests__/ankiConnect.test.ts
+++ b/src/__tests__/ankiConnect.test.ts
@@ -1,0 +1,176 @@
+import { addSentencesToAnki, addWritingCardToAnki } from '../api/ankiConnect';
+import { AppSettings } from '../types/AppSettings';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as typeof fetch;
+
+const settings: AppSettings = {
+  ankConnect: true,
+  ankiConnectUrl: 'http://localhost:8765',
+  ankiDeck: 'TestDeck',
+  ankiModel: 'Basic',
+};
+
+const okResponse = (body: unknown = { result: 1, error: null }) =>
+  ({ ok: true, json: async () => body } as Response);
+
+// ─── addSentencesToAnki ───────────────────────────────────────────────────────
+
+describe('addSentencesToAnki', () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it('skips cards with missing text', async () => {
+    await addSentencesToAnki([{ text: '', meaning: 'cat', reading: 'ねこ' }], settings, 'jp-JP');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('skips cards with missing meaning', async () => {
+    await addSentencesToAnki([{ text: '猫', meaning: '', reading: 'ねこ' }], settings, 'jp-JP');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('skips cards with missing reading', async () => {
+    await addSentencesToAnki([{ text: '猫', meaning: 'cat', reading: '' }], settings, 'jp-JP');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('uses "Tango Card Format" model for Japanese', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse());
+    await addSentencesToAnki([{ text: '猫', meaning: 'cat', reading: 'ねこ' }], settings, 'jp-JP');
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.params.note.modelName).toBe('Tango Card Format');
+  });
+
+  it('uses "Chinese deck" model for Chinese', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse());
+    await addSentencesToAnki([{ text: '猫', meaning: 'cat', reading: 'māo' }], settings, 'zh-CN');
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.params.note.modelName).toBe('Chinese deck');
+  });
+
+  it('maps card fields to Expression, Meaning, Reading', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse());
+    await addSentencesToAnki([{ text: '猫', meaning: 'cat', reading: 'ねこ' }], settings, 'jp-JP');
+    const fields = JSON.parse(mockFetch.mock.calls[0][1].body).params.note.fields;
+    expect(fields).toEqual({ Expression: '猫', Meaning: 'cat', Reading: 'ねこ' });
+  });
+
+  it('uses the configured deck name', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse());
+    await addSentencesToAnki([{ text: '猫', meaning: 'cat', reading: 'ねこ' }], settings, 'jp-JP');
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.params.note.deckName).toBe('TestDeck');
+  });
+
+  it('returns a success result for a saved card', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse());
+    const results = await addSentencesToAnki([{ text: '猫', meaning: 'cat', reading: 'ねこ' }], settings, 'jp-JP');
+    expect(results[0].success).toContain('猫');
+  });
+
+  it('returns an error result for a non-ok HTTP response', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, statusText: 'Bad Request', json: async () => ({}) } as Response);
+    const results = await addSentencesToAnki([{ text: '猫', meaning: 'cat', reading: 'ねこ' }], settings, 'jp-JP');
+    expect(results[0].error).toBeDefined();
+  });
+
+  it('returns an error result on network failure', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+    const results = await addSentencesToAnki([{ text: '猫', meaning: 'cat', reading: 'ねこ' }], settings, 'jp-JP');
+    expect(results[0].error).toBeDefined();
+  });
+
+  it('processes multiple cards independently', async () => {
+    mockFetch.mockResolvedValue(okResponse());
+    const cards = [
+      { text: '猫', meaning: 'cat', reading: 'ねこ' },
+      { text: '犬', meaning: 'dog', reading: 'いぬ' },
+    ];
+    const results = await addSentencesToAnki(cards, settings, 'jp-JP');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(results).toHaveLength(2);
+  });
+});
+
+// ─── addWritingCardToAnki ─────────────────────────────────────────────────────
+
+describe('addWritingCardToAnki', () => {
+  const jpCard = { word: '猫', reading: 'ねこ', sentence: '猫が好き', level: '5', meaning: 'cat', diagramBase64: null };
+  const cnCard = { word: '猫', reading: 'māo', sentence: '猫很可爱', level: '3', meaning: 'cat', diagramBase64: null };
+
+  beforeEach(() => mockFetch.mockReset());
+
+  it('uses "Writing Cards Japanese" model for jp-JP', async () => {
+    mockFetch.mockResolvedValueOnce({ json: async () => ({ result: 1 }) } as Response);
+    await addWritingCardToAnki(jpCard, settings, 'jp-JP');
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.params.note.modelName).toBe('Writing Cards Japanese');
+  });
+
+  it('uses "Writing Cards Chinese" model for zh-CN', async () => {
+    mockFetch.mockResolvedValueOnce({ json: async () => ({ result: 1 }) } as Response);
+    await addWritingCardToAnki(cnCard, settings, 'zh-CN');
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.params.note.modelName).toBe('Writing Cards Chinese');
+  });
+
+  it('maps Japanese fields correctly', async () => {
+    mockFetch.mockResolvedValueOnce({ json: async () => ({ result: 1 }) } as Response);
+    await addWritingCardToAnki(jpCard, settings, 'jp-JP');
+    const fields = JSON.parse(mockFetch.mock.calls[0][1].body).params.note.fields;
+    expect(fields.Kanji).toBe('猫');
+    expect(fields.Kana).toBe('ねこ');
+    expect(fields.KankenLevel).toBe('5');
+  });
+
+  it('maps Chinese fields correctly', async () => {
+    mockFetch.mockResolvedValueOnce({ json: async () => ({ result: 1 }) } as Response);
+    await addWritingCardToAnki(cnCard, settings, 'zh-CN');
+    const fields = JSON.parse(mockFetch.mock.calls[0][1].body).params.note.fields;
+    expect(fields.Hanzi).toBe('猫');
+    expect(fields.Pinyin).toBe('māo');
+    expect(fields.HSKLevel).toBe('3');
+  });
+
+  it('builds SentenceFront by replacing the word with its reading', async () => {
+    mockFetch.mockResolvedValueOnce({ json: async () => ({ result: 1 }) } as Response);
+    await addWritingCardToAnki(jpCard, settings, 'jp-JP');
+    const fields = JSON.parse(mockFetch.mock.calls[0][1].body).params.note.fields;
+    expect(fields.SentenceFront).toBe('ねこが好き');
+    expect(fields.SentenceBack).toBe('猫が好き');
+  });
+
+  it('attaches a picture when diagramBase64 is provided', async () => {
+    mockFetch.mockResolvedValueOnce({ json: async () => ({ result: 1 }) } as Response);
+    await addWritingCardToAnki({ ...jpCard, diagramBase64: 'base64data' }, settings, 'jp-JP');
+    const note = JSON.parse(mockFetch.mock.calls[0][1].body).params.note;
+    expect(note.picture).toBeDefined();
+    expect(note.picture[0].data).toBe('base64data');
+    expect(note.picture[0].fields).toContain('Diagram');
+  });
+
+  it('omits picture when diagramBase64 is null', async () => {
+    mockFetch.mockResolvedValueOnce({ json: async () => ({ result: 1 }) } as Response);
+    await addWritingCardToAnki(jpCard, settings, 'jp-JP');
+    const note = JSON.parse(mockFetch.mock.calls[0][1].body).params.note;
+    expect(note.picture).toBeUndefined();
+  });
+
+  it('returns success when the API call succeeds', async () => {
+    mockFetch.mockResolvedValueOnce({ json: async () => ({ result: 1 }) } as Response);
+    const result = await addWritingCardToAnki(jpCard, settings, 'jp-JP');
+    expect(result.success).toContain('猫');
+  });
+
+  it('returns the error string when the API returns an error', async () => {
+    mockFetch.mockResolvedValueOnce({ json: async () => ({ error: 'duplicate note' }) } as Response);
+    const result = await addWritingCardToAnki(jpCard, settings, 'jp-JP');
+    expect(result.error).toBe('duplicate note');
+  });
+
+  it('returns an error on network failure', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+    const result = await addWritingCardToAnki(jpCard, settings, 'jp-JP');
+    expect(result.error).toBeDefined();
+  });
+});

--- a/src/__tests__/apiMeaning.test.ts
+++ b/src/__tests__/apiMeaning.test.ts
@@ -1,0 +1,69 @@
+import { ApiClient } from '../api/meaning';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as typeof fetch;
+
+const mockResponse = (body: unknown) => ({
+  json: async () => body,
+  ok: true,
+} as Response);
+
+describe('ApiClient.getSentenceMeaning', () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it('posts to the /meaning endpoint', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ reply: { sentence: '', reading: '', meaning: '' } }));
+    await new ApiClient('tok').getSentenceMeaning({ text: '猫', reading: '', meaning: '' });
+    expect(mockFetch.mock.calls[0][0]).toMatch(/\/meaning$/);
+  });
+
+  it('sends the sentence text and language in the request body', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ reply: { sentence: '', reading: '', meaning: '' } }));
+    await new ApiClient('tok').getSentenceMeaning({ text: '猫', reading: '', meaning: '' }, 'zh-CN');
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body).toMatchObject({ text: '猫', language: 'zh-CN' });
+  });
+
+  it('defaults language to jp-JP', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ reply: { sentence: '', reading: '', meaning: '' } }));
+    await new ApiClient('tok').getSentenceMeaning({ text: '猫', reading: '', meaning: '' });
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.language).toBe('jp-JP');
+  });
+
+  it('sets the Authorization header with the access token', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ reply: { sentence: '', reading: '', meaning: '' } }));
+    await new ApiClient('my-secret-token').getSentenceMeaning({ text: '猫', reading: '', meaning: '' });
+    expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe('Bearer my-secret-token');
+  });
+
+  it('returns the API response', async () => {
+    const reply = { sentence: '猫が好き', reading: 'ねこがすき', meaning: 'I like cats' };
+    mockFetch.mockResolvedValueOnce(mockResponse({ reply }));
+    const result = await new ApiClient('tok').getSentenceMeaning({ text: '猫が好き', reading: '', meaning: '' });
+    expect(result.reply).toEqual(reply);
+  });
+});
+
+describe('ApiClient.getPhotoMeaning', () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it('posts to the /meaning/photo endpoint', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ prompt: '', reply: { sentence: '', reading: '', meaning: '' } }));
+    await new ApiClient('tok').getPhotoMeaning('abc', 'image/jpeg');
+    expect(mockFetch.mock.calls[0][0]).toMatch(/\/meaning\/photo$/);
+  });
+
+  it('sends imageBase64, mimeType and language in the request body', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ prompt: '', reply: { sentence: '', reading: '', meaning: '' } }));
+    await new ApiClient('tok').getPhotoMeaning('abc123', 'image/png', 'zh-CN');
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body).toMatchObject({ imageBase64: 'abc123', mimeType: 'image/png', language: 'zh-CN' });
+  });
+
+  it('sets the Authorization header with the access token', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ prompt: '', reply: { sentence: '', reading: '', meaning: '' } }));
+    await new ApiClient('photo-token').getPhotoMeaning('abc', 'image/jpeg');
+    expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe('Bearer photo-token');
+  });
+});

--- a/src/__tests__/csv.test.ts
+++ b/src/__tests__/csv.test.ts
@@ -1,0 +1,45 @@
+import { createCSV } from '../service/csv';
+
+describe('createCSV', () => {
+  it('starts with a UTF-8 BOM', () => {
+    expect(createCSV([]).startsWith('﻿')).toBe(true);
+  });
+
+  it('includes a header row with Sentence, Reading, Meaning', () => {
+    const csv = createCSV([]);
+    expect(csv).toContain('Sentence');
+    expect(csv).toContain('Reading');
+    expect(csv).toContain('Meaning');
+  });
+
+  it('maps each card to a data row', () => {
+    const csv = createCSV([
+      { text: '猫が好き', reading: 'ねこがすき', meaning: 'I like cats' },
+      { text: '犬', reading: 'いぬ', meaning: 'dog' },
+    ]);
+    expect(csv).toContain('猫が好き');
+    expect(csv).toContain('ねこがすき');
+    expect(csv).toContain('I like cats');
+    expect(csv).toContain('犬');
+    expect(csv).toContain('いぬ');
+    expect(csv).toContain('dog');
+  });
+
+  it('returns only the header row for an empty list', () => {
+    const csv = createCSV([]);
+    const lines = csv.replace('﻿', '').trim().split('\n');
+    expect(lines).toHaveLength(1);
+  });
+
+  it('produces one data row per card', () => {
+    const cards = [
+      { text: 'a', reading: 'b', meaning: 'c' },
+      { text: 'd', reading: 'e', meaning: 'f' },
+      { text: 'g', reading: 'h', meaning: 'i' },
+    ];
+    const csv = createCSV(cards);
+    const lines = csv.replace('﻿', '').trim().split('\n');
+    // header + 3 data rows
+    expect(lines).toHaveLength(4);
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "jsx": "react-jsx",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
-    "types": ["node", "react", "react-dom"]
+    "types": ["node", "react", "react-dom", "jest"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "build"]


### PR DESCRIPTION
## Summary

- **58 tests across 5 suites**, all passing locally
- Adds `npm test` and `npx tsc --noEmit` as required CI steps
- Adds `@testing-library/dom@^10` (required peer dep for `@testing-library/react@16`)

## Test coverage

| File | What's tested |
|------|--------------|
| `csv.test.ts` | UTF-8 BOM, header row, data rows, empty list, row count |
| `apiMeaning.test.ts` | POST endpoints, request body, auth header, language default, response shape |
| `ankiConnect.test.ts` | Skipping incomplete cards, JP/CN model names, field mapping, sentence-front construction, diagram attachment, HTTP error and network failure |
| `Settings.test.tsx` | Modal open/close, checkbox/URL/deck callbacks, save-closes-modal |
| `Cards.test.tsx` | localStorage init/load/persist, add sentence, clear (confirm/cancel), tab navigation, photo-OCR tab JWT permission gate, language selection & persistence |

## Notes

- This branch is based on `deps/upgrade-dependencies` (PR #15) to pick up the testing library upgrades. It should be merged after that PR.
- Canvas-heavy features (PhotoOCR drawing, diagram generation) are left untested here — those would need `jest-canvas-mock` or a separate integration test strategy.

## Test plan

- [ ] `CI=true npm test -- --watchAll=false` passes (58/58 locally)
- [ ] `npx tsc --noEmit` passes

https://claude.ai/code/session_01A4UZncgERVNx2kudhi7c8X

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4UZncgERVNx2kudhi7c8X)_