### PR TITLE
Add camera capture button to OCR section for mobile browsers

### DIFF
--- a/src/PhotoOCR.tsx
+++ b/src/PhotoOCR.tsx
@@ -29,9 +29,11 @@ function PhotoOCR({ translationLanguage, onCardAdded }: PhotoOCRProps) {
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const imgRef = useRef<HTMLImageElement>(null);
+  const cameraInputRef = useRef<HTMLInputElement>(null);
   const dragStart = useRef<{ x: number; y: number } | null>(null);
 
   const hasScreenCapture = !!(navigator.mediaDevices?.getDisplayMedia);
+  const hasCameraCapture = !!(navigator.mediaDevices?.getUserMedia);
 
   const loadImage = (src: string) => {
     setImgSrc(src);
@@ -227,6 +229,19 @@ function PhotoOCR({ translationLanguage, onCardAdded }: PhotoOCRProps) {
           <input type="file" accept="image/*" onChange={onFileChange} style={{ display: "none" }} />
           {t("upload_image")}
         </label>
+        {hasCameraCapture && (
+          <label className="photo-ocr-upload-btn">
+            <input
+              ref={cameraInputRef}
+              type="file"
+              accept="image/*"
+              capture="environment"
+              onChange={onFileChange}
+              style={{ display: "none" }}
+            />
+            {t("take_photo")}
+          </label>
+        )}
         {hasScreenCapture && (
           <button className="button-alt" onClick={handleScreenCapture}>
             {t("capture_screen")}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -24,6 +24,7 @@
   "tab_text": "Text",
   "tab_photo": "OCR Photo",
   "upload_image": "Upload Image",
+  "take_photo": "Take Photo",
   "capture_screen": "Capture Screen",
   "drag_to_select": "Drag to select regions in reading order. They will be stacked in the order drawn. Leave unselected to use the whole image.",
   "remove_last": "Remove last region",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -24,6 +24,7 @@
   "tab_text": "テキスト",
   "tab_photo": "OCR写真",
   "upload_image": "画像をアップロード",
+  "take_photo": "写真を撮る",
   "capture_screen": "スクリーンをキャプチャ",
   "drag_to_select": "読む順番にドラッグして範囲を選択。描いた順番に積み重ねて送信されます。選択しない場合は画像全体を使用します。",
   "remove_last": "最後の範囲を削除",


### PR DESCRIPTION
Uses input[capture=environment] which opens the native camera on phones
(iOS Safari, Android Chrome). Shown only when getUserMedia is available
as a proxy for camera-capable devices. Reuses the existing onFileChange
handler so the captured photo flows through the same OCR pipeline.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JW1UUXiR8ZMAP2zxHZjv44