### PR TITLE
Preserve card formatting and make worksheets more printer-friendly

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -730,6 +730,12 @@ button:active {
   margin-bottom: 20px;
 }
 
+/* No writing box: items are just numbered lines, so pack them tighter --
+   this is what turns a many-page printout into one or two pages. */
+.worksheet-item--compact {
+  margin-bottom: 10px;
+}
+
 .worksheet-num {
   font-weight: bold;
 }
@@ -739,6 +745,14 @@ button:active {
   font-size: 20px;
   line-height: 1.8;
   margin-bottom: 8px;
+}
+
+.worksheet-item--compact .worksheet-prompt {
+  margin-bottom: 0;
+}
+
+.worksheet-prompt u {
+  text-underline-offset: 3px;
 }
 
 .worksheet-writing-box {

--- a/src/KanjiWorksheet.tsx
+++ b/src/KanjiWorksheet.tsx
@@ -18,6 +18,10 @@ function KanjiWorksheet({ settings }: KanjiWorksheetProps) {
   );
   const [maxCards, setMaxCards] = useState("");
   const [includeAnswerKey, setIncludeAnswerKey] = useState(true);
+  // Off by default: most people writing kanji by hand use a separate
+  // notebook, and skipping the boxes turns a many-page printout into a
+  // couple of pages.
+  const [includeWritingBoxes, setIncludeWritingBoxes] = useState(false);
   const [items, setItems] = useState<WorksheetItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
@@ -79,6 +83,14 @@ function KanjiWorksheet({ settings }: KanjiWorksheetProps) {
           />
           {t("worksheet_include_answer_key")}
         </label>
+        <label className="worksheet-checkbox-label">
+          <input
+            type="checkbox"
+            checked={includeWritingBoxes}
+            onChange={(e) => setIncludeWritingBoxes(e.target.checked)}
+          />
+          {t("worksheet_include_writing_boxes")}
+        </label>
       </div>
 
       <button className="button-alt" onClick={handleFetch} disabled={!deck || isLoading}>
@@ -104,17 +116,15 @@ function KanjiWorksheet({ settings }: KanjiWorksheetProps) {
             <h2 className="worksheet-title">{t("worksheet_title")}</h2>
 
             {items.map((item, index) => (
-              <div className="worksheet-item" key={index}>
+              <div
+                className={`worksheet-item${includeWritingBoxes ? "" : " worksheet-item--compact"}`}
+                key={index}
+              >
                 <div className="worksheet-prompt">
                   <span className="worksheet-num">{index + 1}.</span>{" "}
-                  {item.prompt.split("\n").map((line, lineIndex) => (
-                    <span key={lineIndex}>
-                      {lineIndex > 0 && <br />}
-                      {line}
-                    </span>
-                  ))}
+                  <span dangerouslySetInnerHTML={{ __html: item.promptHtml }} />
                 </div>
-                <div className="worksheet-writing-box" />
+                {includeWritingBoxes && <div className="worksheet-writing-box" />}
               </div>
             ))}
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -58,6 +58,7 @@
   "worksheet_max_cards": "Max cards",
   "worksheet_no_limit": "No limit",
   "worksheet_include_answer_key": "Include answer key",
+  "worksheet_include_writing_boxes": "Include writing boxes",
   "worksheet_fetch": "Fetch due cards",
   "worksheet_loading": "Fetching...",
   "worksheet_card_count": "{{count}} card(s) loaded",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -58,6 +58,7 @@
   "worksheet_max_cards": "最大カード数",
   "worksheet_no_limit": "制限なし",
   "worksheet_include_answer_key": "解答欄を含める",
+  "worksheet_include_writing_boxes": "書き取り欄を含める",
   "worksheet_fetch": "期限のカードを取得",
   "worksheet_loading": "取得中...",
   "worksheet_card_count": "{{count}}枚のカードを読み込みました",

--- a/src/service/worksheet.ts
+++ b/src/service/worksheet.ts
@@ -1,11 +1,58 @@
 import { AnkiCardInfo } from "../types/AnkiConnect";
 
 export type WorksheetItem = {
-  prompt: string;
+  promptHtml: string;
   answer: string | null;
 };
 
 const BLOCK_TAGS = new Set(["div", "p", "tr", "li", "br"]);
+const INLINE_FORMAT_TAGS = new Set(["u", "b", "strong", "em", "i", "mark", "s", "strike"]);
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/**
+ * Convert Anki card HTML into a small, safe HTML string for rendering in the
+ * worksheet: text is escaped from scratch (nothing from the original markup
+ * passes through unescaped) and only a short allowlist of inline formatting
+ * tags (<u>, <b>, <em>, ...) survives, since Anki cards commonly underline
+ * or bold the target word/reading and that cue is worth keeping on the
+ * worksheet. Everything else (styling classes, <span>, <ruby>/<rt>, etc.) is
+ * unwrapped -- its text is kept, the tag is dropped.
+ */
+export function sanitizeCardHtml(rawHtml: string): string {
+  if (!rawHtml) return "";
+
+  const doc = new DOMParser().parseFromString(rawHtml, "text/html");
+  doc.querySelectorAll("style, script").forEach((el) => el.remove());
+
+  const render = (node: ChildNode): string => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      return escapeHtml(node.textContent ?? "");
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) return "";
+
+    const el = node as Element;
+    const tag = el.tagName.toLowerCase();
+    const inner = Array.from(el.childNodes).map(render).join("");
+
+    if (tag === "br") return "<br>";
+    if (BLOCK_TAGS.has(tag)) return inner + "<br>";
+    if (INLINE_FORMAT_TAGS.has(tag)) return `<${tag}>${inner}</${tag}>`;
+    return inner;
+  };
+
+  let html = Array.from(doc.body.childNodes).map(render).join("");
+
+  html = html
+    .replace(/[ \t]+/g, " ")
+    .replace(/(\s*<br>\s*){2,}/g, "<br>")
+    .replace(/^(\s*<br>\s*)+/, "")
+    .replace(/(\s*<br>\s*)+$/, "");
+
+  return html.trim();
+}
 
 /**
  * Convert Anki card HTML into plain text, preserving line breaks.
@@ -54,17 +101,26 @@ export function stripHtml(rawHtml: string): string {
     .join("\n");
 }
 
-// This app's own writing-card note models ("Writing Cards Japanese" /
-// "Writing Cards Chinese", see api/ankiConnect.ts addWritingCardToAnki)
-// always use SentenceFront as the context sentence and Kanji/Hanzi as the
-// target character, so those are checked first. The rest are fallbacks for
-// decks that contain cards from other note types/sources.
+// Fallback field names, used only when a card's rendered `question` HTML
+// (see extractPrompt below) is empty. This app's own writing-card note
+// models use SentenceFront/Kanji/Hanzi (see api/ankiConnect.ts
+// addWritingCardToAnki).
 //
 // ADJUST ME: if your deck uses a note type with different field names, add
 // them here (or reorder) once you've inspected the "no answer field
 // matched" messages logged to the console.
 const PROMPT_FIELD_CANDIDATES = ["SentenceFront", "Sentence", "Context"];
 const ANSWER_FIELD_CANDIDATES = ["Kanji", "Hanzi", "Answer", "Back", "Target", "Expression", "漢字"];
+
+function findFormattedFieldValue(fields: AnkiCardInfo["fields"], candidates: string[]): string | null {
+  for (const name of candidates) {
+    if (fields[name]?.value) {
+      const value = sanitizeCardHtml(fields[name].value);
+      if (value) return value;
+    }
+  }
+  return null;
+}
 
 function findFieldValue(fields: AnkiCardInfo["fields"], candidates: string[]): string | null {
   for (const name of candidates) {
@@ -92,18 +148,26 @@ export function extractAnswer(card: AnkiCardInfo): string | null {
   return findFieldValue(card.fields || {}, ANSWER_FIELD_CANDIDATES);
 }
 
-/** Extract the printable prompt/context sentence for a card. */
+/**
+ * Extract the printable prompt/context sentence for a card, as safe HTML
+ * (see sanitizeCardHtml).
+ *
+ * Prefers the card's rendered `question` HTML -- i.e. literally what Anki
+ * shows on the front of the card -- over the raw field values, because
+ * formatting cues like an underlined target word are often applied by the
+ * card template (or added by hand in Anki's rich-text field editor) and
+ * only show up in the rendered HTML, not in a plain field value.
+ */
 export function extractPrompt(card: AnkiCardInfo): string {
-  const fields = card.fields || {};
+  const questionHtml = sanitizeCardHtml(card.question);
+  if (questionHtml) return questionHtml;
 
-  const knownField = findFieldValue(fields, PROMPT_FIELD_CANDIDATES);
+  const fields = card.fields || {};
+  const knownField = findFormattedFieldValue(fields, PROMPT_FIELD_CANDIDATES);
   if (knownField) return knownField;
 
-  const questionText = stripHtml(card.question);
-  if (questionText) return questionText;
-
   const firstField = Object.values(fields)[0];
-  if (firstField?.value) return stripHtml(firstField.value);
+  if (firstField?.value) return sanitizeCardHtml(firstField.value);
 
   return "";
 }
@@ -111,7 +175,7 @@ export function extractPrompt(card: AnkiCardInfo): string {
 /** Turn raw AnkiConnect card objects into printable worksheet items. */
 export function buildWorksheetItems(cards: AnkiCardInfo[]): WorksheetItem[] {
   return cards.map((card) => {
-    const prompt = extractPrompt(card);
+    const promptHtml = extractPrompt(card);
     const answer = extractAnswer(card);
     if (answer === null) {
       // Helpful for adjusting ANSWER_FIELD_CANDIDATES to your note type.
@@ -121,7 +185,7 @@ export function buildWorksheetItems(cards: AnkiCardInfo[]): WorksheetItem[] {
         ).join(", ")}`
       );
     }
-    return { prompt, answer };
+    return { promptHtml, answer };
   });
 }
 


### PR DESCRIPTION
## Summary
- Preserve inline formatting (underline/bold/etc.) from Anki card HTML in worksheet prompts, instead of stripping it to plain text. Added `sanitizeCardHtml()`, which keeps a small allowlist of inline tags (`u`, `b`, `strong`, `em`, `i`, `mark`, `s`) while escaping everything else from scratch, so it's safe to render.
- `extractPrompt()` now prefers the card's rendered `question` HTML (what's actually shown on the card front, including template/editor-applied formatting) over raw field values.
- Add an "Include writing boxes" checkbox, off by default, so worksheets print as a compact numbered list instead of leaving a large blank writing box under every item — this was inflating printouts to dozens of pages.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run build` (CI=true) compiles cleanly
- [x] Verified against a mocked AnkiConnect response shaped like a real card with an underlined word inside a `<style>`-carrying question HTML: confirms a real `<u>` DOM element renders (not just visually underlined text), the `<style>` block content doesn't leak into the page text, no writing boxes appear by default, and toggling the checkbox adds them back


---
_Generated by [Claude Code](https://claude.ai/code/session_01EV7Eh2gbfLdooB1Y4XzXHJ)_