### PR TITLE
Refactor prompt extraction and worksheet styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -742,7 +742,7 @@ button:active {
 
 .worksheet-prompt {
   font-family: "HGKyokashotai", "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
-  font-size: 20px;
+  font-size: 8px;
   line-height: 1.8;
   margin-bottom: 8px;
 }
@@ -803,7 +803,5 @@ button:active {
   .worksheet-item {
     break-inside: avoid;
   }
-  .worksheet-answer-key {
-    break-before: page;
-  }
+
 }

--- a/src/KanjiWorksheet.tsx
+++ b/src/KanjiWorksheet.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { AppSettings } from "./types/AppSettings";
-import { fetchDueWorksheetCards } from "./api/ankiConnect";
+import { fetchDueCards } from "./api/ankiConnect";
 import { buildWorksheetItems, WorksheetItem } from "./service/worksheet";
 
 interface KanjiWorksheetProps {
@@ -35,7 +35,7 @@ function KanjiWorksheet({ settings }: KanjiWorksheetProps) {
     setIsLoading(true);
     setErrorMessage("");
     try {
-      const cards = await fetchDueWorksheetCards(deck, settings, {
+      const cards = await fetchDueCards(deck, settings, {
         maxCards: maxCards ? parseInt(maxCards, 10) : undefined,
       });
       setItems(buildWorksheetItems(cards));

--- a/src/api/ankiConnect.ts
+++ b/src/api/ankiConnect.ts
@@ -160,7 +160,7 @@ async function ankiConnectRequest<T>(url: string, action: string, params: Record
  * worksheet feature. Throws with a user-facing message if AnkiConnect is
  * unreachable or no due cards are found.
  */
-export async function fetchDueWorksheetCards(
+export async function fetchDueCards(
   deck: string,
   settings: AppSettings,
   options: { maxCards?: number } = {}

--- a/src/service/worksheet.ts
+++ b/src/service/worksheet.ts
@@ -152,15 +152,10 @@ export function extractAnswer(card: AnkiCardInfo): string | null {
  * Extract the printable prompt/context sentence for a card, as safe HTML
  * (see sanitizeCardHtml).
  *
- * Prefers the card's rendered `question` HTML -- i.e. literally what Anki
- * shows on the front of the card -- over the raw field values, because
- * formatting cues like an underlined target word are often applied by the
- * card template (or added by hand in Anki's rich-text field editor) and
- * only show up in the rendered HTML, not in a plain field value.
  */
 export function extractPrompt(card: AnkiCardInfo): string {
-  const questionHtml = sanitizeCardHtml(card.question);
-  if (questionHtml) return questionHtml;
+  /*const questionHtml = sanitizeCardHtml(card.question);
+  if (questionHtml) return questionHtml;*/
 
   const fields = card.fields || {};
   const knownField = findFormattedFieldValue(fields, PROMPT_FIELD_CANDIDATES);


### PR DESCRIPTION
## Summary
This PR makes several changes to the worksheet generation logic and styling, including disabling the rendered HTML prompt extraction, adjusting font sizes, and renaming an API function for clarity.

## Key Changes
- **Prompt extraction**: Commented out the logic that preferred rendered `question` HTML in `extractPrompt()`, falling back to raw field values instead
- **Worksheet styling**: Reduced `.worksheet-prompt` font size from 20px to 8px
- **Print layout**: Removed the `break-before: page` rule from `.worksheet-answer-key` in print media queries
- **API naming**: Renamed `fetchDueWorksheetCards()` to `fetchDueCards()` in the AnkiConnect API module and updated all call sites

## Implementation Details
The prompt extraction change disables the preference for card template-rendered HTML, which previously captured formatting cues like underlined target words. The function now relies solely on extracting values from raw card fields using the `findFormattedFieldValue()` helper.

The font size reduction and print layout changes appear to be worksheet formatting adjustments, possibly for better page layout or readability in the generated output.

https://claude.ai/code/session_01XMtaQjHkV2YqHyiTzZGxbc