### PR TITLE
Auto-fit answer key into more columns on wide pages

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -768,7 +768,8 @@ button:active {
 }
 
 .worksheet-answer-list {
-  column-count: 2;
+  column-width: 120px;
+  column-gap: 16px;
   list-style: none;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Switch from a fixed column-count to column-width so the browser packs in as many ~120px columns as fit the page instead of always 2.


Claude-Session: https://claude.ai/code/session_01XMtaQjHkV2YqHyiTzZGxbc